### PR TITLE
Frontend Docker Image

### DIFF
--- a/.github/workflows/build-deploy.yaml
+++ b/.github/workflows/build-deploy.yaml
@@ -40,7 +40,7 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           context: thallium-${{ inputs.project }}
-          file: ${{ inputs.dockerfile || 'Dockerfile' }}
+          file: thallium-${{ inputs.project }}/${{ inputs.dockerfile || 'Dockerfile' }}
           push: ${{ github.ref == 'refs/heads/main' }}
           cache-from: type=registry,ref=ghcr.io/owl-corp/thallium-${{ inputs.project }}:latest
           cache-to: type=inline

--- a/.github/workflows/build-deploy.yaml
+++ b/.github/workflows/build-deploy.yaml
@@ -9,6 +9,10 @@ on:
           description: "The project to build and push"
           required: true
           type: string
+      dockerfile:
+          description: "The Dockerfile to use for the build"
+          required: false
+          type: string
 
 jobs:
   build:
@@ -36,6 +40,7 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           context: thallium-${{ inputs.project }}
+          file: ${{ inputs.dockerfile || 'Dockerfile' }}
           push: ${{ github.ref == 'refs/heads/main' }}
           cache-from: type=registry,ref=ghcr.io/owl-corp/thallium-${{ inputs.project }}:latest
           cache-to: type=inline

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -68,5 +68,5 @@ jobs:
     with:
       sha-tag: ${{ needs.generate-inputs.outputs.sha-tag }}
       project: frontend
-      dockerfile: thallium-frontend/Dockerfile.development
+      dockerfile: Dockerfile.development
     secrets: inherit

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -15,6 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       backend: ${{ steps.changes.outputs.backend }}
+      frontend: ${{ steps.changes.outputs.frontend }}
     steps:
     - uses: actions/checkout@v4
     - uses: dorny/paths-filter@v3
@@ -27,6 +28,9 @@ jobs:
           backend:
             - *automation
             - 'thallium-backend/**'
+          frontend:
+            - *automation
+            - 'thallium-frontend/**'
 
   generate-inputs:
     runs-on: ubuntu-latest
@@ -55,4 +59,14 @@ jobs:
     with:
       sha-tag: ${{ needs.generate-inputs.outputs.sha-tag }}
       project: backend
+    secrets: inherit
+
+  build-frontend:
+    if: ${{ needs.changes.outputs.frontend == 'true' }}
+    needs: [changes, generate-inputs, lint-frontend]
+    uses: ./.github/workflows/build-deploy.yaml
+    with:
+      sha-tag: ${{ needs.generate-inputs.outputs.sha-tag }}
+      project: frontend
+      dockerfile: Dockerfile.development
     secrets: inherit

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -68,5 +68,5 @@ jobs:
     with:
       sha-tag: ${{ needs.generate-inputs.outputs.sha-tag }}
       project: frontend
-      dockerfile: Dockerfile.development
+      dockerfile: thallium-frontend/Dockerfile.development
     secrets: inherit

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,7 @@ services:
     ports:
       - "15432:5432"
 
-  thallium:
+  thallium-backend:
     build: thallium-backend
     restart: unless-stopped
     command: ["alembic upgrade head && uvicorn src.app:fastapi_app --host 0.0.0.0 --port 8000 --reload"]
@@ -30,3 +30,15 @@ services:
     depends_on:
       postgres:
         condition: service_healthy
+
+  thallium-frontend:
+    build:
+      context: thallium-frontend
+      dockerfile: Dockerfile.development
+    restart: unless-stopped
+    volumes:
+      # Once https://github.com/vitejs/vite/issues/9470 has a nice solution, we can make the mount read-only
+      - ./thallium-frontend:/app
+      - /app/node_modules
+    ports:
+      - "5173:5173"

--- a/thallium-frontend/Dockerfile.development
+++ b/thallium-frontend/Dockerfile.development
@@ -1,0 +1,13 @@
+FROM node:20
+
+WORKDIR /app
+RUN npm install -g pnpm
+
+COPY package.json pnpm-lock.yaml ./
+RUN pnpm install
+
+COPY . .
+
+EXPOSE 5173
+
+CMD ["pnpm", "run", "dev", "--host"]

--- a/thallium-frontend/vite.config.ts
+++ b/thallium-frontend/vite.config.ts
@@ -9,6 +9,7 @@ try {
     .toString().replace(/\n$/, "");
 } catch (e) {
   console.error("Failed to get commit hash");
+  console.error(e);
 }
 
 // https://vitejs.dev/config/

--- a/thallium-frontend/vite.config.ts
+++ b/thallium-frontend/vite.config.ts
@@ -2,8 +2,14 @@ import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
 import * as child from "child_process";
 
-const commitHash = child.execSync("git rev-parse --short HEAD")
-  .toString().replace(/\n$/, "");
+let commitHash = "unknown";
+
+try {
+  commitHash = child.execSync("git rev-parse --short HEAD")
+    .toString().replace(/\n$/, "");
+} catch (e) {
+  console.error("Failed to get commit hash");
+}
 
 // https://vitejs.dev/config/
 export default defineConfig({


### PR DESCRIPTION
Add a Docker image for running the development version of the frontend locally.

This spins up the Vite development server in a Docker container allowing for live-reloading with changes in the `thallium-frontend` directory.

Since we don't deploy the application with Docker, this is not an optimised image and runs with the development server (rather than some sort of static file hosting software with the built image).

If desired, it should still be possible to have the container eject a built version by running it with `pnpm run build`, though this may be missing things such as git context which cannot be detected (we do not mount the .git folder in the root, only the subdirectory).